### PR TITLE
VG-8503: fix so tasks load.

### DIFF
--- a/processing/tasks/utils/task_utils.py
+++ b/processing/tasks/utils/task_utils.py
@@ -694,12 +694,14 @@ def from_wkt(wkt, sr):
 
 
 def get_ssl_mode():
-    value = os.environ['VOYAGER_SSL_MODE']
-    if value.lower() == 'verify':
-        return True
-    else:
+    try:
+        value = os.environ['VOYAGER_SSL_MODE']
+        if value.lower() == 'verify':
+            return True
+        else:
+            return False
+    except KeyError:
         return False
-
 
 def get_spatial_reference(factory_code):
     """Returns spatial reference object.


### PR DESCRIPTION
Had to handle keyerror when tasks load. Gabriel's fix was to add the VERIFY_SSL_MODE env value on task execute only. 